### PR TITLE
Save IPP attributes when receiving requests

### DIFF
--- a/app/src/main/java/com/google/virtualprinter/printer/PrinterService.kt
+++ b/app/src/main/java/com/google/virtualprinter/printer/PrinterService.kt
@@ -60,6 +60,8 @@ import java.io.ByteArrayOutputStream
 import java.net.InetAddress
 import java.net.NetworkInterface
 import java.util.*
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
 import java.net.URI
 import com.google.virtualprinter.utils.PreferenceUtils
 import com.google.virtualprinter.utils.IppAttributesUtils
@@ -87,6 +89,7 @@ class PrinterService(private val context: Context) {
     private var customIppAttributes: List<AttributeGroup>? = null
     private val logger by lazy { PrinterLogger.getInstance(context) }
     private val pluginFramework by lazy { PluginFramework.getInstance(context) }
+    private val jobAttributeCounters = ConcurrentHashMap<Long, AtomicInteger>()
     
     // Add error simulation properties
     private var simulateErrorMode = false
@@ -692,6 +695,9 @@ class PrinterService(private val context: Context) {
                     if (jobId == null) {
                         IppPacket(Status.clientErrorBadRequest, request.requestId)
                     } else {
+                        // Save attributes for analysis
+                        saveIppAttributes(jobId.toLong(), request.attributeGroups, "Get-Job-Attributes")
+
                         // Return job attributes with COMPLETED state
                         val (userName, jobName) = extractJobInfoFromRequest(request)
                         val printerUpTimeSeconds = (SystemClock.elapsedRealtime() / 1000).toInt()
@@ -865,6 +871,14 @@ class PrinterService(private val context: Context) {
                 }
             }
             Operation.validateJob.code -> { // Validate-Job operation
+                // Get job ID from attributes if present
+                val jobId = request.attributeGroups
+                    .find { it.tag == Tag.operationAttributes }
+                    ?.getValues(Types.jobId)
+                    ?.firstOrNull() ?: 0
+
+                // Save attributes for analysis
+                saveIppAttributes(jobId.toLong(), request.attributeGroups, "Validate-Job")
                 IppPacket(Status.successfulOk, request.requestId)
             }
             Operation.createJob.code -> { // Create-Job operation
@@ -902,7 +916,10 @@ class PrinterService(private val context: Context) {
             }
             Operation.getPrinterAttributes.code -> { // Get-Printer-Attributes operation
                 // Priority order: 1) Default 2) Custom Attributes 3) Plugins (highest priority)
-                
+
+                // Save attributes for analysis (Printer attributes don't have a job ID)
+                saveIppAttributes(0L, request.attributeGroups, "Get-Printer-Attributes")
+
                 // Step 1: Get default attributes
                 val defaultResponse = createDefaultPrinterAttributesResponse(request)
                 
@@ -952,6 +969,9 @@ class PrinterService(private val context: Context) {
                     if (jobId == null) {
                         IppPacket(Status.clientErrorBadRequest, request.requestId)
                     } else {
+                        // Save attributes for analysis
+                        saveIppAttributes(jobId.toLong(), request.attributeGroups, "Cancel-Job")
+
                         val queue = PrintJobQueue.getInstance(context)
                         if (queue.cancelJob(jobId.toLong())) {
                             IppPacket(Status.successfulOk, request.requestId)
@@ -1220,8 +1240,11 @@ class PrinterService(private val context: Context) {
                 if (!exists()) mkdirs()
             }
 
+            // Get a counter for each specific job.
+            val counter = jobAttributeCounters.getOrPut(jobId) { AtomicInteger(0) }.incrementAndGet()
+
             val sanitizedPrinterName = getPrinterName().replace(Regex("[^a-zA-Z0-9]"), "_")
-            val fileName = "attr_${sanitizedPrinterName}_job_${jobId}_${operationName}.txt"
+            val fileName = "attr_${sanitizedPrinterName}_job_${jobId}_${operationName}_${"%04d".format(counter)}.txt"
             val file = File(attrDir, fileName)
 
             file.bufferedWriter().use { writer ->

--- a/app/src/main/java/com/google/virtualprinter/printer/PrinterService.kt
+++ b/app/src/main/java/com/google/virtualprinter/printer/PrinterService.kt
@@ -600,6 +600,9 @@ class PrinterService(private val context: Context) {
                         val jobId = System.currentTimeMillis()
                         Log.d(TAG, "Processing Print-Job with ID: $jobId, document size: ${documentData.size} bytes, format: $documentFormat")
                         
+                        // Save attributes for analysis
+                        saveIppAttributes(jobId, request.attributeGroups, "Print-Job")
+
                         // Register job in queue for plugin hooks
                         val job = com.google.virtualprinter.queue.PrintJob(
                             id = jobId,
@@ -789,6 +792,10 @@ class PrinterService(private val context: Context) {
                         
                         // Use the job ID from the request or generate a new one
                         val actualJobId = if (jobId != null && jobId > 0) jobId.toLong() else System.currentTimeMillis()
+
+                        // Save attributes for analysis
+                        saveIppAttributes(actualJobId, request.attributeGroups, "Send-Document")
+
                         val job = com.google.virtualprinter.queue.PrintJob(
                             id = actualJobId,
                             name = request.attributeGroups.find { it.tag == Tag.operationAttributes }?.getValues(Types.jobName)?.firstOrNull()?.toString() ?: "Send Document",
@@ -866,6 +873,9 @@ class PrinterService(private val context: Context) {
                     Log.d(TAG, "Create-Job operation: Assigning job ID: $jobId")
                     Log.d(TAG, "Job attributes: ${request.attributeGroups}")
                     
+                    // Save attributes for analysis
+                    saveIppAttributes(jobId, request.attributeGroups, "Create-Job")
+
                     // Create a response with job attributes
                     val response = IppPacket(
                         Status.successfulOk,
@@ -1201,6 +1211,36 @@ class PrinterService(private val context: Context) {
         )
     }
     
+    /**
+     * Saves IPP attributes to a file for analysis.
+     */
+    private fun saveIppAttributes(jobId: Long, attributeGroups: List<AttributeGroup>, operationName: String) {
+        try {
+            val attrDir = File(context.filesDir, "ipp_attributes").apply {
+                if (!exists()) mkdirs()
+            }
+
+            val sanitizedPrinterName = getPrinterName().replace(Regex("[^a-zA-Z0-9]"), "_")
+            val fileName = "attr_${sanitizedPrinterName}_job_${jobId}_${operationName}.txt"
+            val file = File(attrDir, fileName)
+
+            file.bufferedWriter().use { writer ->
+                writer.write("Operation: $operationName\n")
+                writer.write("Printer: ${getPrinterName()}\n")
+                writer.write("Job ID: $jobId\n")
+                writer.write("Timestamp: ${java.util.Date()}\n")
+                writer.write("------------------------------------------\n\n")
+
+                attributeGroups.forEach { group ->
+                    writer.write("$group\n\n")
+                }
+            }
+            Log.d(TAG, "Saved IPP attributes to: ${file.absolutePath}")
+        } catch (e: Exception) {
+            Log.e(TAG, "Error saving IPP attributes", e)
+        }
+    }
+
     private fun saveDocument(docBytes: ByteArray, jobId: Long = System.currentTimeMillis(), documentFormat: String = "application/octet-stream") {
         try {
             // Log incoming document format

--- a/app/src/main/java/com/google/virtualprinter/utils/PreferenceUtils.kt
+++ b/app/src/main/java/com/google/virtualprinter/utils/PreferenceUtils.kt
@@ -18,21 +18,70 @@ package com.google.virtualprinter.utils
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.util.Log
+import org.json.JSONObject
+import java.io.File
 
 /**
  * Utility class for managing app preferences
  */
 object PreferenceUtils {
+    private const val TAG = "PreferenceUtils"
     private const val PREFS_NAME = "printer_preferences"
     private const val KEY_PRINTER_NAME = "printer_name"
     private const val DEFAULT_PRINTER_NAME = "Android Virtual Printer"
     
+    private const val CONFIG_FILE_NAME = "printer_config.json"
+    private const val KEY_CONFIG_PRINTER_NAME = "printer_name"
+
     /**
      * Gets the user-defined printer name or the default name if not set
+     * Checks in this order:
+     * 1. SharedPreferences (user-set in UI)
+     * 2. Configuration file (installed on device)
+     * 3. Default constant
      */
     fun getCustomPrinterName(context: Context): String {
         val prefs = getPreferences(context)
-        return prefs.getString(KEY_PRINTER_NAME, DEFAULT_PRINTER_NAME) ?: DEFAULT_PRINTER_NAME
+
+        // 1. Check SharedPreferences first (user preference in UI)
+        val savedName = prefs.getString(KEY_PRINTER_NAME, null)
+        if (savedName != null && savedName.isNotEmpty()) {
+            return savedName
+        }
+
+        // 2. Check for configuration file
+        val configName = getNameFromConfigFile(context)
+        if (configName != null) {
+            return configName
+        }
+
+        // 3. Fallback to default
+        return DEFAULT_PRINTER_NAME
+    }
+
+    /**
+     * Reads the printer name from a configuration file if it exists.
+     */
+    private fun getNameFromConfigFile(context: Context): String? {
+        val configFile = File(context.filesDir, CONFIG_FILE_NAME)
+        if (configFile.exists()) {
+            Log.d(TAG, "Reading config from ${configFile.absolutePath}")
+            try {
+                val content = configFile.readText()
+                val json = JSONObject(content)
+                if (json.has(KEY_CONFIG_PRINTER_NAME)) {
+                    val name = json.getString(KEY_CONFIG_PRINTER_NAME)
+                    if (name.isNotEmpty()) {
+                      Log.d(TAG, "Printer name: $name")
+                      return name
+                    }
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Error reading config file ${configFile.absolutePath}", e)
+            }
+        }
+        return null
     }
     
     /**


### PR DESCRIPTION
For Create-Job, Print-Job, and Send-Document, save the corresponding IPP attributes from the client.
