### PR TITLE
Allow configurable compression-supported

### DIFF
--- a/app/src/main/java/com/google/virtualprinter/printer/PrinterService.kt
+++ b/app/src/main/java/com/google/virtualprinter/printer/PrinterService.kt
@@ -1043,7 +1043,7 @@ class PrinterService(private val context: Context) {
             Types.uriAuthenticationSupported.of("none"),
             
             // Compression support (required)
-            Types.compressionSupported.of("none"),
+            Types.compressionSupported.of(PreferenceUtils.getCompressionSupported(context)),
             
             // PDL override support (required)
             Types.pdlOverrideSupported.of("not-attempted"),

--- a/app/src/main/java/com/google/virtualprinter/printer/PrinterService.kt
+++ b/app/src/main/java/com/google/virtualprinter/printer/PrinterService.kt
@@ -1240,7 +1240,7 @@ class PrinterService(private val context: Context) {
      */
     private fun saveIppAttributes(jobId: Int, attributeGroups: List<AttributeGroup>, operationName: String) {
         try {
-            val attrDir = File(context.filesDir, "ipp_attributes").apply {
+            val attrDir = File(context.filesDir, "saved_ipp_attributes").apply {
                 if (!exists()) mkdirs()
             }
 
@@ -1272,7 +1272,12 @@ class PrinterService(private val context: Context) {
         try {
             // Log incoming document format
             Log.d(TAG, "Saving document with format: $documentFormat and size: ${docBytes.size} bytes")
-            
+
+            // Save the exact bytes received from the client for debugging/logging
+            val originalFile = File(printJobsDirectory, "print_job_${jobId}.ipp")
+            FileOutputStream(originalFile).use { it.write(docBytes) }
+            Log.d(TAG, "Saved exact client bytes to: ${originalFile.absolutePath}")
+
             // First, try to extract actual document content from IPP wrapper
             val extractedContent = extractDocumentFromIPP(docBytes)
             if (extractedContent != null) {

--- a/app/src/main/java/com/google/virtualprinter/printer/PrinterService.kt
+++ b/app/src/main/java/com/google/virtualprinter/printer/PrinterService.kt
@@ -529,7 +529,7 @@ class PrinterService(private val context: Context) {
                             id = generateJobId().toLong(),
                             name = "Temp Job for Delay",
                             filePath = "temp",
-                            documentFormat = PreferenceUtils.getSupportedFormats(context).firstOrNull() ?: "application/pdf",
+                            documentFormat = PreferenceUtils.getDefaultFormat(context),
                             size = documentData.size.toLong(),
                             submissionTime = System.currentTimeMillis(),
                             state = com.google.virtualprinter.queue.PrintJobState.PENDING
@@ -707,7 +707,7 @@ class PrinterService(private val context: Context) {
                             ),
                             buildJobAttributes(
                                 jobId = jobId,
-                                documentFormat = PreferenceUtils.getSupportedFormats(context).firstOrNull() ?: "application/pdf",
+                                documentFormat = PreferenceUtils.getDefaultFormat(context),
                                 jobState = JobState.completed,
                                 jobStateReason = "job-completed-successfully",
                                 jobName = "Print Job $jobId",
@@ -732,7 +732,7 @@ class PrinterService(private val context: Context) {
                             id = generateJobId().toLong(),
                             name = "Temp Job for Send-Document Delay",
                             filePath = "temp",
-                            documentFormat = PreferenceUtils.getSupportedFormats(context).firstOrNull() ?: "application/pdf",
+                            documentFormat = PreferenceUtils.getDefaultFormat(context),
                             size = documentData.size.toLong(),
                             submissionTime = System.currentTimeMillis(),
                             state = com.google.virtualprinter.queue.PrintJobState.PENDING
@@ -1008,9 +1008,6 @@ class PrinterService(private val context: Context) {
             URI.create("ipp://127.0.0.1:$PORT/")
         }
 
-        // The list of supported document formats.
-        val supportedFormats = PreferenceUtils.getSupportedFormats(context)
-
         // Create printer attributes group with all required IPP attributes
         val printerAttributes = AttributeGroup.groupOf(
             Tag.printerAttributes,
@@ -1049,9 +1046,9 @@ class PrinterService(private val context: Context) {
             Types.pdlOverrideSupported.of("not-attempted"),
             
             // Supported document formats
-            Types.documentFormatSupported.of(supportedFormats),
-            Types.documentFormat.of(supportedFormats.firstOrNull() ?: "application/pdf"),
-            Types.documentFormatDefault.of(supportedFormats.firstOrNull() ?: "application/pdf"),
+            Types.documentFormatSupported.of(PreferenceUtils.getSupportedFormats(context)),
+            Types.documentFormat.of(PreferenceUtils.getDefaultFormat(context)),
+            Types.documentFormatDefault.of(PreferenceUtils.getDefaultFormat(context)),
             
             // Media support
             Types.mediaDefault.of("iso_a4_210x297mm"),
@@ -1778,7 +1775,7 @@ class PrinterService(private val context: Context) {
                         id = currentTime + attempt,
                         name = "Error Test Job #${attempt + 1}",
                         filePath = "test_error.pdf",
-                        documentFormat = PreferenceUtils.getSupportedFormats(context).firstOrNull() ?: "application/pdf",
+                        documentFormat = PreferenceUtils.getDefaultFormat(context),
                         size = 1024L,
                         submissionTime = currentTime,
                         state = PrintJobState.PENDING,
@@ -1854,7 +1851,7 @@ class PrinterService(private val context: Context) {
                 id = currentTime,
                 name = "Delay Test Job",
                 filePath = "test.pdf",
-                documentFormat = PreferenceUtils.getSupportedFormats(context).firstOrNull() ?: "application/pdf",
+                documentFormat = PreferenceUtils.getDefaultFormat(context),
                 size = 1024L,
                 submissionTime = currentTime,
                 state = PrintJobState.PENDING,

--- a/app/src/main/java/com/google/virtualprinter/printer/PrinterService.kt
+++ b/app/src/main/java/com/google/virtualprinter/printer/PrinterService.kt
@@ -529,7 +529,7 @@ class PrinterService(private val context: Context) {
                             id = generateJobId().toLong(),
                             name = "Temp Job for Delay",
                             filePath = "temp",
-                            documentFormat = "application/pdf",
+                            documentFormat = PreferenceUtils.getSupportedFormats(context).firstOrNull() ?: "application/pdf",
                             size = documentData.size.toLong(),
                             submissionTime = System.currentTimeMillis(),
                             state = com.google.virtualprinter.queue.PrintJobState.PENDING
@@ -574,16 +574,7 @@ class PrinterService(private val context: Context) {
                     
                     // Check supported document formats (use custom list if provided)
                     val customSupported = getCustomAttributeValues("document-format-supported")
-                    val supportedFormats = if (customSupported.isNotEmpty()) customSupported else listOf(
-                        "application/octet-stream",
-                        "application/pdf",
-                        "application/postscript",
-                        "application/vnd.cups-pdf",
-                        "application/vnd.cups-postscript",
-                        "application/vnd.cups-raw",
-                        "image/jpeg",
-                        "image/png"
-                    )
+                    val supportedFormats = if (customSupported.isNotEmpty()) customSupported else PreferenceUtils.getSupportedFormats(context)
                     
                     if (documentFormat !in supportedFormats) {
                         Log.w(TAG, "Unsupported document format: $documentFormat")
@@ -716,7 +707,7 @@ class PrinterService(private val context: Context) {
                             ),
                             buildJobAttributes(
                                 jobId = jobId,
-                                documentFormat = "application/pdf",
+                                documentFormat = PreferenceUtils.getSupportedFormats(context).firstOrNull() ?: "application/pdf",
                                 jobState = JobState.completed,
                                 jobStateReason = "job-completed-successfully",
                                 jobName = "Print Job $jobId",
@@ -741,7 +732,7 @@ class PrinterService(private val context: Context) {
                             id = generateJobId().toLong(),
                             name = "Temp Job for Send-Document Delay",
                             filePath = "temp",
-                            documentFormat = "application/pdf",
+                            documentFormat = PreferenceUtils.getSupportedFormats(context).firstOrNull() ?: "application/pdf",
                             size = documentData.size.toLong(),
                             submissionTime = System.currentTimeMillis(),
                             state = com.google.virtualprinter.queue.PrintJobState.PENDING
@@ -1016,7 +1007,10 @@ class PrinterService(private val context: Context) {
             Log.e(TAG, "Error creating printer URI: ${e.message}")
             URI.create("ipp://127.0.0.1:$PORT/")
         }
-        
+
+        // The list of supported document formats.
+        val supportedFormats = PreferenceUtils.getSupportedFormats(context)
+
         // Create printer attributes group with all required IPP attributes
         val printerAttributes = AttributeGroup.groupOf(
             Tag.printerAttributes,
@@ -1055,17 +1049,9 @@ class PrinterService(private val context: Context) {
             Types.pdlOverrideSupported.of("not-attempted"),
             
             // Supported document formats
-            Types.documentFormatSupported.of(
-                "application/pdf", 
-                "application/octet-stream",
-                "application/vnd.cups-raw",
-                "application/vnd.cups-pdf",
-                "image/jpeg",
-                "image/png",
-                "text/plain"
-            ),
-            Types.documentFormat.of("application/pdf"),
-            Types.documentFormatDefault.of("application/pdf"),
+            Types.documentFormatSupported.of(supportedFormats),
+            Types.documentFormat.of(supportedFormats.firstOrNull() ?: "application/pdf"),
+            Types.documentFormatDefault.of(supportedFormats.firstOrNull() ?: "application/pdf"),
             
             // Media support
             Types.mediaDefault.of("iso_a4_210x297mm"),
@@ -1499,13 +1485,16 @@ class PrinterService(private val context: Context) {
                 serviceType = SERVICE_TYPE
                 port = PORT
                 
+                val supportedFormats = PreferenceUtils.getSupportedFormats(context)
+                val pdlValue = supportedFormats.joinToString(",")
+
                 // Add printer attributes as TXT records
                 val hostAddress = getLocalIpAddress() ?: "127.0.0.1"
                 val attributes = mapOf(
                     "URF" to "none",
                     "adminurl" to "http://$hostAddress:$PORT/",
                     "rp" to "ipp/print", // Resource path for IPP
-                    "pdl" to "application/pdf,image/urf",
+                    "pdl" to pdlValue,
                     "txtvers" to "1",
                     "priority" to "30",
                     "qtotal" to "1",
@@ -1789,7 +1778,7 @@ class PrinterService(private val context: Context) {
                         id = currentTime + attempt,
                         name = "Error Test Job #${attempt + 1}",
                         filePath = "test_error.pdf",
-                        documentFormat = "application/pdf",
+                        documentFormat = PreferenceUtils.getSupportedFormats(context).firstOrNull() ?: "application/pdf",
                         size = 1024L,
                         submissionTime = currentTime,
                         state = PrintJobState.PENDING,
@@ -1865,7 +1854,7 @@ class PrinterService(private val context: Context) {
                 id = currentTime,
                 name = "Delay Test Job",
                 filePath = "test.pdf",
-                documentFormat = "application/pdf",
+                documentFormat = PreferenceUtils.getSupportedFormats(context).firstOrNull() ?: "application/pdf",
                 size = 1024L,
                 submissionTime = currentTime,
                 state = PrintJobState.PENDING,

--- a/app/src/main/java/com/google/virtualprinter/utils/PreferenceUtils.kt
+++ b/app/src/main/java/com/google/virtualprinter/utils/PreferenceUtils.kt
@@ -34,6 +34,7 @@ object PreferenceUtils {
     private const val CONFIG_FILE_NAME = "printer_config.json"
     private const val KEY_CONFIG_PRINTER_NAME = "printer_name"
     private const val KEY_CONFIG_SUPPORTED_FORMATS = "supported_formats"
+    private const val KEY_CONFIG_COMPRESSION_SUPPORTED = "compression_supported"
 
     private val DEFAULT_SUPPORTED_FORMATS = listOf(
         "application/pdf",
@@ -121,6 +122,34 @@ object PreferenceUtils {
             }
         }
         return DEFAULT_SUPPORTED_FORMATS
+    }
+
+    /**
+     * Gets the list of supported compression algorithms.
+     * Checks the configuration file first, then falls back to defaults.
+     */
+    fun getCompressionSupported(context: Context): List<String> {
+        val configFile = File(context.filesDir, CONFIG_FILE_NAME)
+        if (configFile.exists()) {
+            try {
+                val content = configFile.readText()
+                val json = JSONObject(content)
+                if (json.has(KEY_CONFIG_COMPRESSION_SUPPORTED)) {
+                    val compressionArray = json.getJSONArray(KEY_CONFIG_COMPRESSION_SUPPORTED)
+                    val compressions = mutableListOf<String>()
+                    for (i in 0 until compressionArray.length()) {
+                        compressions.add(compressionArray.getString(i))
+                    }
+                    if (compressions.isNotEmpty()) {
+                        Log.d(TAG, "Found supported compressions in config: $compressions")
+                        return compressions
+                    }
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Error reading config file ${configFile.absolutePath}", e)
+            }
+        }
+        return listOf("none")
     }
     
     /**

--- a/app/src/main/java/com/google/virtualprinter/utils/PreferenceUtils.kt
+++ b/app/src/main/java/com/google/virtualprinter/utils/PreferenceUtils.kt
@@ -38,12 +38,9 @@ object PreferenceUtils {
 
     private val DEFAULT_SUPPORTED_FORMATS = listOf(
         "application/pdf",
-        "application/octet-stream",
-        "application/vnd.cups-raw",
-        "application/vnd.cups-pdf",
+        "image/pwg-raster",
+        "application/PCLm",
         "image/jpeg",
-        "image/png",
-        "text/plain"
     )
 
     /**
@@ -122,6 +119,14 @@ object PreferenceUtils {
             }
         }
         return DEFAULT_SUPPORTED_FORMATS
+    }
+
+    /**
+     * Return the default document format (the first value from supported formats, or a hard-coded
+     * default value).
+     */
+    fun getDefaultFormat(context: Context): String {
+      return getSupportedFormats(context).firstOrNull() ?: "application/pdf"
     }
 
     /**

--- a/app/src/main/java/com/google/virtualprinter/utils/PreferenceUtils.kt
+++ b/app/src/main/java/com/google/virtualprinter/utils/PreferenceUtils.kt
@@ -33,6 +33,17 @@ object PreferenceUtils {
     
     private const val CONFIG_FILE_NAME = "printer_config.json"
     private const val KEY_CONFIG_PRINTER_NAME = "printer_name"
+    private const val KEY_CONFIG_SUPPORTED_FORMATS = "supported_formats"
+
+    private val DEFAULT_SUPPORTED_FORMATS = listOf(
+        "application/pdf",
+        "application/octet-stream",
+        "application/vnd.cups-raw",
+        "application/vnd.cups-pdf",
+        "image/jpeg",
+        "image/png",
+        "text/plain"
+    )
 
     /**
      * Gets the user-defined printer name or the default name if not set
@@ -82,6 +93,34 @@ object PreferenceUtils {
             }
         }
         return null
+    }
+
+    /**
+     * Gets the list of supported formats for the printer.
+     * Checks the configuration file first, then falls back to defaults.
+     */
+    fun getSupportedFormats(context: Context): List<String> {
+        val configFile = File(context.filesDir, CONFIG_FILE_NAME)
+        if (configFile.exists()) {
+            try {
+                val content = configFile.readText()
+                val json = JSONObject(content)
+                if (json.has(KEY_CONFIG_SUPPORTED_FORMATS)) {
+                    val formatsArray = json.getJSONArray(KEY_CONFIG_SUPPORTED_FORMATS)
+                    val formats = mutableListOf<String>()
+                    for (i in 0 until formatsArray.length()) {
+                        formats.add(formatsArray.getString(i))
+                    }
+                    if (formats.isNotEmpty()) {
+                      Log.d(TAG, "Found supported formats in config: $formats")
+                      return formats
+                    }
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Error reading config file ${configFile.absolutePath}", e)
+            }
+        }
+        return DEFAULT_SUPPORTED_FORMATS
     }
     
     /**


### PR DESCRIPTION
Allow configurable document format support

Save the exact document data sent in an IPP request

This is in addition to the extracted data, such as a PDF file.

Also, updated the saved attributes directory so it doesn't conflict with
the existing ipp attributes capabilities (import attributes from another
printer, export attributes, etc).