### PR TITLE
Clean up IppAttributesUtils and unify IPP attribute parsing

### DIFF
--- a/app/src/main/java/com/google/virtualprinter/printer/PrinterService.kt
+++ b/app/src/main/java/com/google/virtualprinter/printer/PrinterService.kt
@@ -93,6 +93,15 @@ class PrinterService(private val context: Context) {
     private val jobIdCounter = AtomicInteger(1)
     private val printerUuid = PreferenceUtils.getPrinterUuid(context)
 
+    init {
+        // Automatically load the printer config on a background thread if present
+        CoroutineScope(Dispatchers.IO).launch {
+            IppAttributesUtils.loadIppAttributes(context, PreferenceUtils.CONFIG_FILE_NAME)?.let {
+                setCustomIppAttributes(it)
+            }
+        }
+    }
+
     /** Generates a unique, positive 31-bit Job ID */
     private fun generateJobId(): Int = jobIdCounter.getAndIncrement() and 0x7FFFFFFF
     
@@ -919,19 +928,10 @@ class PrinterService(private val context: Context) {
                 // Step 1: Get default attributes
                 val defaultResponse = createDefaultPrinterAttributesResponse(request)
                 
-                // Step 2: Apply custom attributes if set (overrides defaults)
+                // Step 2: Apply custom attributes if set (overlays defaults)
                 val withCustomAttributes = if (customIppAttributes != null) {
-                    Log.d(TAG, "Applying custom IPP attributes (priority 2)")
-                    IppPacket(
-                        Status.successfulOk,
-                        request.requestId,
-                        AttributeGroup.groupOf(
-                            Tag.operationAttributes,
-                            Types.attributesCharset.of("utf-8"),
-                            Types.attributesNaturalLanguage.of("en")
-                        ),
-                        *customIppAttributes!!.toTypedArray()
-                    )
+                    Log.d(TAG, "Overlaying custom IPP attributes (priority 2)")
+                    IppAttributesUtils.overlayAttributes(defaultResponse, customIppAttributes!!)
                 } else {
                     defaultResponse
                 }

--- a/app/src/main/java/com/google/virtualprinter/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/google/virtualprinter/settings/SettingsScreen.kt
@@ -1130,30 +1130,19 @@ private fun handleExportAttributes(context: android.content.Context, uri: Uri, p
         val attributes = printerService.getCustomIppAttributes()
         if (attributes != null) {
             context.contentResolver.openOutputStream(uri)?.use { outputStream ->
-                val jsonArray = org.json.JSONArray()
-                
-                attributes.forEach { group ->
-                    val groupObj = org.json.JSONObject().apply {
-                        put("tag", group.tag.name)
-                        put("attributes", org.json.JSONArray().apply {
-                            IppAttributesUtils.getAttributesFromGroup(group).forEach { attr ->
-                                put(org.json.JSONObject().apply {
-                                    put("name", attr.name)
-                                    put("value", attr.toString())
-                                    put("type", "STRING") // Default type
-                                })
-                            }
-                        })
-                    }
-                    jsonArray.put(groupObj)
+                if (IppAttributesUtils.saveIppAttributes(outputStream, attributes)) {
+                    android.widget.Toast.makeText(
+                        context,
+                        "IPP attributes exported successfully",
+                        android.widget.Toast.LENGTH_SHORT
+                    ).show()
+                } else {
+                    android.widget.Toast.makeText(
+                        context,
+                        "Failed to export IPP attributes",
+                        android.widget.Toast.LENGTH_SHORT
+                    ).show()
                 }
-                
-                outputStream.write(jsonArray.toString().toByteArray())
-                android.widget.Toast.makeText(
-                    context,
-                    "IPP attributes exported successfully",
-                    android.widget.Toast.LENGTH_SHORT
-                ).show()
             }
         } else {
             android.widget.Toast.makeText(

--- a/app/src/main/java/com/google/virtualprinter/utils/IppAttributesUtils.kt
+++ b/app/src/main/java/com/google/virtualprinter/utils/IppAttributesUtils.kt
@@ -17,675 +17,275 @@
 package com.google.virtualprinter.utils
 
 import android.content.Context
-import android.net.Uri
 import android.util.Log
 import com.hp.jipp.encoding.Attribute
 import com.hp.jipp.encoding.AttributeGroup
-import com.hp.jipp.encoding.AttributeType
+import com.hp.jipp.encoding.BooleanType
+import com.hp.jipp.encoding.CollectionType
+import com.hp.jipp.encoding.EnumType
+import com.hp.jipp.encoding.IntOrIntRange
+import com.hp.jipp.encoding.IntOrIntRangeType
+import com.hp.jipp.encoding.IntType
+import com.hp.jipp.encoding.IppPacket
+import com.hp.jipp.encoding.KeywordOrName
+import com.hp.jipp.encoding.Resolution
+import com.hp.jipp.encoding.ResolutionType
+import com.hp.jipp.encoding.StringType
 import com.hp.jipp.encoding.Tag
-import com.hp.jipp.model.Types
+import com.hp.jipp.encoding.UntypedCollection
+import com.hp.jipp.encoding.UriType
+import java.io.File
+import java.io.FileOutputStream
+import java.io.OutputStream
+import java.net.URI
 import org.json.JSONArray
 import org.json.JSONObject
-import java.io.File
-import java.io.FileInputStream
-import java.io.FileOutputStream
-import java.io.IOException
-import java.util.NoSuchElementException
-import java.util.ListIterator
-import io.ktor.server.response.*
-import java.io.OutputStream
 
 object IppAttributesUtils {
     private const val TAG = "IppAttributesUtils"
-    private const val PREFS_NAME = "printer_preferences"
-    private const val KEY_IPP_ATTRIBUTES = "ipp_attributes"
     private const val CUSTOM_ATTRIBUTES_DIR = "ipp_attributes"
-    
-    /**
-     * Saves IPP attributes to a JSON file
-     */
-    fun saveIppAttributes(
-        outputStream: OutputStream,
-        attributes: List<AttributeGroup>
-    ): Boolean {
-        return try {
-            val jsonArray = buildAttributesJson(attributes)
 
-            outputStream.use {
-                it.write(jsonArray.toString().toByteArray())
+    /**
+     * Converts a list of AttributeGroups into a structured JSON string matching the RFC 8011
+     * schema.
+     */
+    fun ippAttributesToJson(attributes: List<AttributeGroup>): String {
+        val root = JSONObject()
+        for (group in attributes) {
+            val groupKey =
+                when (group.tag) {
+                    Tag.operationAttributes -> "operation-attributes"
+                    Tag.jobAttributes -> "job-attributes"
+                    Tag.printerAttributes -> "printer-attributes"
+                    else -> continue
+                }
+            val groupJson =
+                root.optJSONObject(groupKey) ?: JSONObject().also { root.put(groupKey, it) }
+            for (attr in group) {
+                val attrObj = JSONObject()
+                val typeName = getAttributeTypeName(attr)
+                attrObj.put("type", typeName)
+                if (attr.size > 1) {
+                    val list = (0 until attr.size).map { extractString(attr[it]) }
+                    attrObj.put("value", JSONArray(list))
+                } else {
+                    val value = attr.getValue()
+                    when (value) {
+                        is Boolean,
+                        is Number -> attrObj.put("value", value)
+                        else -> attrObj.put("value", extractString(value))
+                    }
+                }
+                groupJson.put(attr.name, attrObj)
             }
+        }
+        return root.toString(2)
+    }
+
+    /**
+     * Extracts a raw string from any IPP attribute value object (String, KeywordOrName, Name, Text,
+     * etc.).
+     */
+    fun extractString(obj: Any?): String {
+        if (obj == null) return ""
+        if (obj is String) return obj
+        if (obj is KeywordOrName) return obj.keyword ?: obj.name?.value ?: obj.toString()
+        try {
+            val field = obj.javaClass.getDeclaredField("value").apply { isAccessible = true }
+            val v = field.get(obj)
+            if (v != null) return v.toString()
+        } catch (_: Exception) {}
+        try {
+            val field = obj.javaClass.getDeclaredField("name").apply { isAccessible = true }
+            val v = field.get(obj)
+            if (v != null) return extractString(v)
+        } catch (_: Exception) {}
+        return obj.toString()
+    }
+
+    private fun getAttributeTypeName(attr: Attribute<*>): String {
+        val type = IppAttributesParser.nameToType[attr.name] ?: attr.type
+
+        // Unify single and multi-valued StringType tags
+        val stringTag = (type as? StringType)?.tag ?: (type as? StringType.Set)?.tag
+        if (stringTag != null) {
+            return when (stringTag) {
+                Tag.nameWithoutLanguage -> "nameWithoutLanguage"
+                Tag.nameWithLanguage -> "nameWithLanguage"
+                Tag.textWithoutLanguage -> "textWithoutLanguage"
+                Tag.textWithLanguage -> "textWithLanguage"
+                Tag.mimeMediaType -> "mimeMediaType"
+                Tag.charset -> "charset"
+                Tag.naturalLanguage -> "naturalLanguage"
+                Tag.uriScheme -> "urischeme"
+                else -> "keyword"
+            }
+        }
+
+        return when (type) {
+            is BooleanType -> "boolean"
+            is IntType -> "integer"
+            is IntOrIntRangeType -> "rangeOfInteger"
+            is ResolutionType -> "resolution"
+            is UriType -> "uri"
+            is EnumType<*> -> "enum"
+            is CollectionType<*>,
+            is UntypedCollection.Type,
+            is UntypedCollection.SetType -> "collection"
+            else ->
+                when (attr.getValue()) {
+                    is Boolean -> "boolean"
+                    is Number -> "integer"
+                    is IntOrIntRange -> "rangeOfInteger"
+                    is Resolution -> "resolution"
+                    is URI -> "uri"
+                    else -> "keyword"
+                }
+        }
+    }
+
+    /** Saves IPP attributes to an output stream as JSON. */
+    fun saveIppAttributes(outputStream: OutputStream, attributes: List<AttributeGroup>): Boolean {
+        return try {
+            val jsonString = ippAttributesToJson(attributes)
+            outputStream.use { it.write(jsonString.toByteArray()) }
             true
         } catch (e: Exception) {
             Log.e(TAG, "Error saving IPP attributes to stream", e)
             false
         }
     }
-    private fun buildAttributesJson(
-        attributes: List<AttributeGroup>
-    ): JSONArray {
-        val jsonArray = JSONArray()
 
-        attributes.forEach { group ->
-            val groupObj = JSONObject().apply {
-                put("tag", group.tag.name)
-                put("attributes", JSONArray().apply {
-                    val attributesInGroup = getAttributesFromGroup(group)
-                    attributesInGroup.forEach { attr ->
-                        put(JSONObject().apply {
-                            put("name", attr.name)
-                            put("value", attr.toString())
-                            put("type", getAttributeType(attr))
-                        })
-                    }
-                })
-            }
-            jsonArray.put(groupObj)
-        }
-
-        return jsonArray
-    }
-
-    fun saveIppAttributes(context: Context, attributes: List<AttributeGroup>, filename: String): Boolean {
-        try {
-            val attributesDir = File(context.filesDir, CUSTOM_ATTRIBUTES_DIR)
-            if (!attributesDir.exists()) {
-                attributesDir.mkdirs()
-            }
-            
-            val file = File(attributesDir, filename)
-            val jsonArray = buildAttributesJson(attributes)
-            
-            FileOutputStream(file).use { it.write(jsonArray.toString().toByteArray()) }
-            Log.d(TAG, "Saved IPP attributes to: ${file.absolutePath}")
-            return true
-        } catch (e: Exception) {
-            Log.e(TAG, "Error saving IPP attributes", e)
-            return false
-        }
-    }
-    
-    /**
-     * Helper method to get all attributes from a group
-     * 
-     * Since AttributeGroup implements Iterable<Attribute<*>>, we can directly iterate
-     * over the attributes without using reflection. This is more reliable and performant.
-     */
-    fun getAttributesFromGroup(group: AttributeGroup): List<Attribute<*>> {
+    /** Saves IPP attributes in the custom attributes directory as JSON. */
+    fun saveIppAttributes(
+        context: Context,
+        attributes: List<AttributeGroup>,
+        filename: String,
+    ): Boolean {
         return try {
-            // AttributeGroup implements Iterable<Attribute<*>>, so we can iterate directly
-            group.toList()
+            val jsonString = ippAttributesToJson(attributes)
+            val attributesDir =
+                File(context.filesDir, CUSTOM_ATTRIBUTES_DIR).apply { if (!exists()) mkdirs() }
+            val file = File(attributesDir, filename)
+            FileOutputStream(file).use { it.write(jsonString.toByteArray()) }
+            Log.d(TAG, "Saved IPP attributes as JSON to: ${file.absolutePath}")
+            true
         } catch (e: Exception) {
-            Log.e(TAG, "Unable to iterate attributes in AttributeGroup", e)
-            emptyList()
+            Log.e(TAG, "Error saving IPP attributes as JSON", e)
+            false
         }
     }
-    
-    /**
-     * Helper method to get attribute type as string
-     */
-    private fun getAttributeType(attr: Attribute<*>): String {
-        return when {
-            attr.toString().toIntOrNull() != null -> "INTEGER"
-            attr.toString().equals("true", ignoreCase = true) || 
-            attr.toString().equals("false", ignoreCase = true) -> "BOOLEAN"
-            else -> "STRING"
-        }
-    }
-    
-    /**
-     * Creates an attribute from name, value and type
-     */
-    fun createAttribute(name: String, value: Any, type: String): Attribute<*>? {
-        try {
-            when (type.uppercase()) {
 
-                "INTEGER" -> when (value) {
-                    is Int -> IntAttribute(name, value)
-                    is Long -> IntAttribute(name, value.toInt()) // if IPP only supports Int
-                    else -> {
-                        Log.w(TAG, "Expected INTEGER for $name but got ${value::class.java.simpleName}")
-                        null
-                    }
-                }
-
-                "BOOLEAN" -> when (value) {
-                    is Boolean -> BooleanAttribute(name, value)
-                    else -> {
-                        Log.w(TAG, "Expected BOOLEAN for $name but got ${value::class.java.simpleName}")
-                        null
-                    }
-                }
-
-                "STRING" -> when (value) {
-                    is String -> StringAttribute(name, value)
-                    else -> {
-                        Log.w(TAG, "Expected STRING for $name but got ${value::class.java.simpleName}")
-                        null
-                    }
-                }
-
-                else -> {
-                    Log.w(TAG, "Unsupported attribute type $type for $name")
-                    null
-                }
-            }
-        } catch (e: Exception) {
-            Log.e(TAG, "Error creating attribute: $name", e)
-        }
-        return null
-    }
-    
-    // Basic attribute implementations
-    private class StringAttribute(override val name: String, private val value: String) : Attribute<String> {
-        override val size: Int = 1
-        override val type = object : AttributeType<String> {
-            override val name: String get() = this@StringAttribute.name
-            override fun coerce(value: Any): String? = value as? String
-        }
-        override fun isEmpty(): Boolean = false
-        
-        override fun get(index: Int): String {
-            if (index != 0) throw IndexOutOfBoundsException()
-            return value
-        }
-        override fun getValue(): String? = value
-        override fun indexOf(element: String): Int = if (element == value) 0 else -1
-        override fun lastIndexOf(element: String): Int = indexOf(element)
-        
-        override fun contains(element: String): Boolean = element == value
-        override fun containsAll(elements: Collection<String>): Boolean = elements.all { contains(it) }
-        override fun toString(): String = value
-        
-        override fun iterator(): Iterator<String> = object : Iterator<String> {
-            private var hasNext = true
-            
-            override fun hasNext(): Boolean = hasNext
-            
-            override fun next(): String {
-                if (!hasNext) throw NoSuchElementException()
-                hasNext = false
-                return value
-            }
-        }
-        
-        override fun listIterator(): kotlin.collections.ListIterator<String> = object : kotlin.collections.ListIterator<String> {
-            private var index = 0
-            
-            override fun hasNext(): Boolean = index == 0
-            override fun hasPrevious(): Boolean = index == 1
-            override fun next(): String {
-                if (!hasNext()) throw NoSuchElementException()
-                index++
-                return value
-            }
-            override fun nextIndex(): Int = if (hasNext()) 0 else 1
-            override fun previous(): String {
-                if (!hasPrevious()) throw NoSuchElementException()
-                index--
-                return value
-            }
-            override fun previousIndex(): Int = if (hasPrevious()) 0 else -1
-        }
-        
-        override fun listIterator(index: Int): kotlin.collections.ListIterator<String> {
-            if (index < 0 || index > 1) {
-                throw IndexOutOfBoundsException("Index: $index, Size: 1")
-            }
-            return object : kotlin.collections.ListIterator<String> {
-                private var idx = index
-                
-                override fun hasNext(): Boolean = idx == 0
-                override fun hasPrevious(): Boolean = idx == 1
-                override fun next(): String {
-                    if (!hasNext()) throw NoSuchElementException()
-                    idx++
-                    return value
-                }
-                override fun nextIndex(): Int = if (hasNext()) 0 else 1
-                override fun previous(): String {
-                    if (!hasPrevious()) throw NoSuchElementException()
-                    idx--
-                    return value
-                }
-                override fun previousIndex(): Int = if (hasPrevious()) 0 else -1
-            }
-        }
-        
-        override fun subList(fromIndex: Int, toIndex: Int): List<String> {
-            if (fromIndex < 0 || toIndex > 1 || fromIndex > toIndex) {
-                throw IndexOutOfBoundsException("fromIndex: $fromIndex, toIndex: $toIndex, size: 1")
-            }
-            
-            return if (fromIndex == toIndex) {
-                emptyList()
-            } else {
-                listOf(value)
-            }
-        }
-    }
-    
-    // Multi-value string attribute implementation
-    private class MultiStringAttribute(override val name: String, private val values: List<String>) : Attribute<String> {
-        override val size: Int = values.size
-        override val type = object : AttributeType<String> {
-            override val name: String get() = this@MultiStringAttribute.name
-            override fun coerce(value: Any): String? = value as? String
-        }
-        override fun isEmpty(): Boolean = values.isEmpty()
-
-        override fun get(index: Int): String {
-            if (index < 0 || index >= values.size) throw IndexOutOfBoundsException()
-            return values[index]
-        }
-        override fun getValue(): String? = values.firstOrNull()
-        override fun indexOf(element: String): Int = values.indexOf(element)
-        override fun lastIndexOf(element: String): Int = values.lastIndexOf(element)
-
-        override fun contains(element: String): Boolean = values.contains(element)
-        override fun containsAll(elements: Collection<String>): Boolean = values.containsAll(elements)
-        override fun toString(): String = values.joinToString(",")
-
-        override fun iterator(): Iterator<String> = values.iterator()
-        override fun listIterator(): kotlin.collections.ListIterator<String> = values.listIterator()
-        override fun listIterator(index: Int): kotlin.collections.ListIterator<String> = values.listIterator(index)
-        override fun subList(fromIndex: Int, toIndex: Int): List<String> = values.subList(fromIndex, toIndex)
-    }
-    
-    private class IntAttribute(override val name: String, private val value: Int) : Attribute<Int> {
-        override val size: Int = 1
-        override val type = object : AttributeType<Int> {
-            override val name: String get() = this@IntAttribute.name
-            override fun coerce(value: Any): Int? = (value as? Int) ?: (value as? String)?.toIntOrNull()
-        }
-        override fun isEmpty(): Boolean = false
-        
-        override fun get(index: Int): Int {
-            if (index != 0) throw IndexOutOfBoundsException()
-            return value
-        }
-        override fun getValue(): Int? = value
-        override fun indexOf(element: Int): Int = if (element == value) 0 else -1
-        override fun lastIndexOf(element: Int): Int = indexOf(element)
-        
-        override fun contains(element: Int): Boolean = element == value
-        override fun containsAll(elements: Collection<Int>): Boolean = elements.all { contains(it) }
-        override fun toString(): String = value.toString()
-        
-        override fun iterator(): Iterator<Int> = object : Iterator<Int> {
-            private var hasNext = true
-            
-            override fun hasNext(): Boolean = hasNext
-            
-            override fun next(): Int {
-                if (!hasNext) throw NoSuchElementException()
-                hasNext = false
-                return value
-            }
-        }
-        
-        override fun listIterator(): kotlin.collections.ListIterator<Int> = object : kotlin.collections.ListIterator<Int> {
-            private var index = 0
-            
-            override fun hasNext(): Boolean = index == 0
-            override fun hasPrevious(): Boolean = index == 1
-            override fun next(): Int {
-                if (!hasNext()) throw NoSuchElementException()
-                index++
-                return value
-            }
-            override fun nextIndex(): Int = if (hasNext()) 0 else 1
-            override fun previous(): Int {
-                if (!hasPrevious()) throw NoSuchElementException()
-                index--
-                return value
-            }
-            override fun previousIndex(): Int = if (hasPrevious()) 0 else -1
-        }
-        
-        override fun listIterator(index: Int): kotlin.collections.ListIterator<Int> {
-            if (index < 0 || index > 1) {
-                throw IndexOutOfBoundsException("Index: $index, Size: 1")
-            }
-            return object : kotlin.collections.ListIterator<Int> {
-                private var idx = index
-                
-                override fun hasNext(): Boolean = idx == 0
-                override fun hasPrevious(): Boolean = idx == 1
-                override fun next(): Int {
-                    if (!hasNext()) throw NoSuchElementException()
-                    idx++
-                    return value
-                }
-                override fun nextIndex(): Int = if (hasNext()) 0 else 1
-                override fun previous(): Int {
-                    if (!hasPrevious()) throw NoSuchElementException()
-                    idx--
-                    return value
-                }
-                override fun previousIndex(): Int = if (hasPrevious()) 0 else -1
-            }
-        }
-        
-        override fun subList(fromIndex: Int, toIndex: Int): List<Int> {
-            if (fromIndex < 0 || toIndex > 1 || fromIndex > toIndex) {
-                throw IndexOutOfBoundsException("fromIndex: $fromIndex, toIndex: $toIndex, size: 1")
-            }
-            
-            return if (fromIndex == toIndex) {
-                emptyList()
-            } else {
-                listOf(value)
-            }
-        }
-    }
-    
-    private class BooleanAttribute(override val name: String, private val value: Boolean) : Attribute<Boolean> {
-        override val size: Int = 1
-        override val type = object : AttributeType<Boolean> {
-            override val name: String get() = this@BooleanAttribute.name
-            override fun coerce(value: Any): Boolean? = when(value) {
-                is Boolean -> value
-                is String -> value.equals("true", ignoreCase = true)
-                else -> null
-            }
-        }
-        override fun isEmpty(): Boolean = false
-        
-        override fun get(index: Int): Boolean {
-            if (index != 0) throw IndexOutOfBoundsException()
-            return value
-        }
-        override fun getValue(): Boolean? = value
-        override fun indexOf(element: Boolean): Int = if (element == value) 0 else -1
-        override fun lastIndexOf(element: Boolean): Int = indexOf(element)
-        
-        override fun contains(element: Boolean): Boolean = element == value
-        override fun containsAll(elements: Collection<Boolean>): Boolean = elements.all { contains(it) }
-        override fun toString(): String = value.toString()
-        
-        override fun iterator(): Iterator<Boolean> = object : Iterator<Boolean> {
-            private var hasNext = true
-            
-            override fun hasNext(): Boolean = hasNext
-            
-            override fun next(): Boolean {
-                if (!hasNext) throw NoSuchElementException()
-                hasNext = false
-                return value
-            }
-        }
-        
-        override fun listIterator(): kotlin.collections.ListIterator<Boolean> = object : kotlin.collections.ListIterator<Boolean> {
-            private var index = 0
-            
-            override fun hasNext(): Boolean = index == 0
-            override fun hasPrevious(): Boolean = index == 1
-            override fun next(): Boolean {
-                if (!hasNext()) throw NoSuchElementException()
-                index++
-                return value
-            }
-            override fun nextIndex(): Int = if (hasNext()) 0 else 1
-            override fun previous(): Boolean {
-                if (!hasPrevious()) throw NoSuchElementException()
-                index--
-                return value
-            }
-            override fun previousIndex(): Int = if (hasPrevious()) 0 else -1
-        }
-        
-        override fun listIterator(index: Int): kotlin.collections.ListIterator<Boolean> {
-            if (index < 0 || index > 1) {
-                throw IndexOutOfBoundsException("Index: $index, Size: 1")
-            }
-            return object : kotlin.collections.ListIterator<Boolean> {
-                private var idx = index
-                
-                override fun hasNext(): Boolean = idx == 0
-                override fun hasPrevious(): Boolean = idx == 1
-                override fun next(): Boolean {
-                    if (!hasNext()) throw NoSuchElementException()
-                    idx++
-                    return value
-                }
-                override fun nextIndex(): Int = if (hasNext()) 0 else 1
-                override fun previous(): Boolean {
-                    if (!hasPrevious()) throw NoSuchElementException()
-                    idx--
-                    return value
-                }
-                override fun previousIndex(): Int = if (hasPrevious()) 0 else -1
-            }
-        }
-        
-        override fun subList(fromIndex: Int, toIndex: Int): List<Boolean> {
-            if (fromIndex < 0 || toIndex > 1 || fromIndex > toIndex) {
-                throw IndexOutOfBoundsException("fromIndex: $fromIndex, toIndex: $toIndex, size: 1")
-            }
-            
-            return if (fromIndex == toIndex) {
-                emptyList()
-            } else {
-                listOf(value)
-            }
-        }
-    }
-    
-    /**
-     * Loads IPP attributes from a JSON file
-     */
-    fun loadIppAttributes(context: Context, filename: String): List<AttributeGroup>? {
-        try {
-            val file = File(context.filesDir, "$CUSTOM_ATTRIBUTES_DIR/$filename")
-            if (!file.exists()) {
-                Log.e(TAG, "IPP attributes file not found: ${file.absolutePath}")
-                return null
-            }
-            
-            val jsonString = FileInputStream(file).bufferedReader().use { it.readText() }
-            val attributeGroups = mutableListOf<AttributeGroup>()
-
-            // Detect format: legacy array vs printer JSON object
-            val trimmed = jsonString.trim()
-            if (trimmed.startsWith("[")) {
-                // Legacy array format
-                val jsonArray = JSONArray(trimmed)
-                parseLegacyAttributeArray(jsonArray, attributeGroups)
-            } else {
-                // New printer JSON format (e.g., { "response": { ... } })
-                val root = try { JSONObject(trimmed) } catch (e: Exception) {
-                    Log.e(TAG, "Invalid JSON object in IPP attributes file", e)
-                    null
-                }
-                if (root != null) {
-                    parsePrinterResponseJson(root, attributeGroups)
-                }
-            }
-
-            Log.d(TAG, "Loaded ${attributeGroups.size} IPP attribute groups from: ${file.absolutePath}")
-            return if (attributeGroups.isNotEmpty()) attributeGroups else null
-        } catch (e: Exception) {
-            Log.e(TAG, "Error loading IPP attributes", e)
+    /** Loads IPP attributes from a JSON file using IppAttributesParser. */
+    fun loadIppAttributes(file: File): List<AttributeGroup>? {
+        if (!file.exists()) {
+            Log.e(TAG, "IPP attributes file not found: ${file.absolutePath}")
             return null
         }
-    }
+        return try {
+            val content = file.readText().trim()
+            val attributeGroups = mutableListOf<AttributeGroup>()
 
-    /**
-     * Parses the legacy array-based schema into AttributeGroups
-     */
-    private fun parseLegacyAttributeArray(jsonArray: JSONArray, out: MutableList<AttributeGroup>) {
-        for (i in 0 until jsonArray.length()) {
-            val groupObj = jsonArray.getJSONObject(i)
-            val tagName = groupObj.optString("tag", "PRINTER_ATTRIBUTES")
-            val tag = getTagByName(tagName) ?: Tag.printerAttributes
-
-            val loadedAttributes = mutableListOf<Attribute<*>>()
-            val attrsJsonArray = groupObj.optJSONArray("attributes") ?: JSONArray()
-            for (j in 0 until attrsJsonArray.length()) {
-                val attrObj = attrsJsonArray.getJSONObject(j)
-                val name = attrObj.optString("name")
-                if (name.isBlank()) continue
-
-                // Prefer multi-value if present
-                if (attrObj.has("values")) {
-                    val valuesArray = attrObj.getJSONArray("values")
-                    val values = (0 until valuesArray.length()).map { idx -> valuesArray.get(idx).toString() }
-                    loadedAttributes.add(MultiStringAttribute(name, values))
-                } else {
-                    val valueString = attrObj.optString("value")
-                    val typeString = attrObj.optString("type", "STRING")
-                    createAttribute(name, valueString, typeString)?.let { loadedAttributes.add(it) }
-                }
-            }
-
-            if (loadedAttributes.isNotEmpty()) {
-                out.add(createAttributeGroup(tag, loadedAttributes))
-            }
-        }
-    }
-
-    /**
-     * Parses printer-style response JSON (like the sample provided) and fills AttributeGroups
-     */
-    private fun parsePrinterResponseJson(root: JSONObject, out: MutableList<AttributeGroup>) {
-        try {
+            val root = JSONObject(content)
             val response = root.optJSONObject("response") ?: root
 
-            // operation-attributes -> OPERATION_ATTRIBUTES group
-            response.optJSONObject("operation-attributes")?.let { opAttrs ->
-                val attrs = parseNameToObjectMap(opAttrs)
+            // 1. Operation attributes if present
+            response.optJSONObject("operation-attributes")?.let { opJson ->
+                val attrs = IppAttributesParser.parse(opJson)
                 if (attrs.isNotEmpty()) {
-                    out.add(createAttributeGroup(Tag.operationAttributes, attrs))
+                    attributeGroups.add(
+                        AttributeGroup.groupOf(Tag.operationAttributes, *attrs.toTypedArray())
+                    )
                 }
             }
 
-            // printer-attributes -> PRINTER_ATTRIBUTES group
-            response.optJSONObject("printer-attributes")?.let { prAttrs ->
-                val attrs = parseNameToObjectMap(prAttrs)
+            // 2. Printer attributes: use "printer-attributes" object if present, or fall back
+            // to using the root object directly if no section headers exist (flat attributes file).
+            val prJson =
+                response.optJSONObject("printer-attributes")
+                    ?: if (!response.has("operation-attributes")) response else null
+            prJson?.let {
+                val attrs = IppAttributesParser.parse(it)
                 if (attrs.isNotEmpty()) {
-                    out.add(createAttributeGroup(Tag.printerAttributes, attrs))
+                    attributeGroups.add(
+                        AttributeGroup.groupOf(Tag.printerAttributes, *attrs.toTypedArray())
+                    )
                 }
             }
+
+            Log.d(
+                TAG,
+                "Loaded ${attributeGroups.size} IPP attribute groups from: ${file.absolutePath}",
+            )
+            if (attributeGroups.isNotEmpty()) attributeGroups else null
         } catch (e: Exception) {
-            Log.e(TAG, "Error parsing printer response JSON", e)
+            Log.e(TAG, "Error loading IPP attributes from ${file.absolutePath}", e)
+            null
         }
     }
 
     /**
-     * Converts a map of attributeName -> { type, value } objects to a list of Attributes
+     * Loads IPP attributes by filename, checking custom_attributes directory and root files
+     * directory.
      */
-    private fun parseNameToObjectMap(container: JSONObject): List<Attribute<*>> {
-        val result = mutableListOf<Attribute<*>>()
-        val names = container.keys()
-        var skippedCount = 0
-        
-        while (names.hasNext()) {
-            val name = names.next()
-            
-            // Skip attributes with invalid names
-            if (name.isBlank()) {
-                skippedCount++
-                continue
-            }
-            
-            try {
-                val obj = container.get(name)
-                var attribute: Attribute<*>? = null
-                
-                when (obj) {
-                    is JSONObject -> {
-                        val type = obj.optString("type", "string").lowercase()
-                        
-                        // Handle multi-valued attributes
-                        if (obj.has("value") && obj.get("value") is JSONArray) {
-                            val arr = obj.getJSONArray("value")
-                            if (arr.length() > 0) {
-                                val values = (0 until arr.length()).map { idx -> 
-                                    val value = arr.get(idx)
-                                    // Handle null values
-                                    if (value == JSONObject.NULL) "" else value.toString()
-                                }
-                                attribute = MultiStringAttribute(name, values)
-                            }
-                        } 
-                        // Handle single-valued attributes
-                        else if (obj.has("value")) {
-                            val valueAny = obj.get("value")
-                            if (valueAny != JSONObject.NULL) {
-                                attribute = makeAttributeFromTypedValue(name, type, valueAny)
-                            }
-                        }
-                        // Handle object without explicit value (treat as JSON string)
-                        else {
-                            attribute = StringAttribute(name, obj.toString())
-                        }
-                    }
-                    is JSONArray -> {
-                        if (obj.length() > 0) {
-                            val values = (0 until obj.length()).map { idx -> 
-                                val value = obj.get(idx)
-                                if (value == JSONObject.NULL) "" else value.toString()
-                            }
-                            attribute = MultiStringAttribute(name, values)
-                        }
-                    }
-                    is String, is Number, is Boolean -> {
-                        // Handle primitive values directly
-                        attribute = StringAttribute(name, obj.toString())
-                    }
-                    else -> {
-                        // Handle other types (including null)
-                        if (obj != JSONObject.NULL) {
-                            attribute = StringAttribute(name, obj.toString())
-                        }
-                    }
-                }
-                
-                if (attribute != null) {
-                    result.add(attribute)
-                } else {
-                    Log.d(TAG, "Skipped attribute '$name' with null/empty value")
-                    skippedCount++
-                }
-                
-            } catch (e: Exception) {
-                Log.w(TAG, "Skipping attribute '$name' due to parse error: ${e.message}", e)
-                skippedCount++
-            }
+    fun loadIppAttributes(context: Context, filename: String): List<AttributeGroup>? {
+        val customFile = File(File(context.filesDir, CUSTOM_ATTRIBUTES_DIR), filename)
+        if (customFile.exists()) {
+            return loadIppAttributes(customFile)
         }
-        
-        Log.d(TAG, "Parsed ${result.size} attributes, skipped $skippedCount from container")
-        return result
+        val directFile = File(context.filesDir, filename)
+        if (directFile.exists()) {
+            return loadIppAttributes(directFile)
+        }
+        Log.e(
+            TAG,
+            "IPP attributes file not found: $filename in $CUSTOM_ATTRIBUTES_DIR or ${context.filesDir}",
+        )
+        return null
     }
 
     /**
-     * Creates an Attribute based on the provided type string and raw value
+     * Overlays custom attributes onto a base IPP packet. Attributes in `overrides` overwrite
+     * matching attributes (by name) in the `basePacket` within the same tag group.
      */
-    private fun makeAttributeFromTypedValue(name: String, type: String, valueAny: Any): Attribute<*>? {
+    fun overlayAttributes(basePacket: IppPacket, overrides: List<AttributeGroup>): IppPacket {
+        val mergedGroups = mutableListOf<AttributeGroup>()
+        val allTags =
+            (basePacket.attributeGroups.map { it.tag } + overrides.map { it.tag }).distinct()
+
+        for (tag in allTags) {
+            val baseGroup = basePacket.attributeGroups.find { it.tag == tag }
+            val overrideGroup = overrides.find { it.tag == tag }
+
+            if (baseGroup != null && overrideGroup != null) {
+                val mergedAttributes = (baseGroup + overrideGroup).associateBy { it.name }.values
+                mergedGroups.add(AttributeGroup.groupOf(tag, *mergedAttributes.toTypedArray()))
+            } else if (overrideGroup != null) {
+                mergedGroups.add(overrideGroup)
+            } else if (baseGroup != null) {
+                mergedGroups.add(baseGroup)
+            }
+        }
+
+        return IppPacket(basePacket.status, basePacket.requestId, *mergedGroups.toTypedArray())
+    }
+
+    /** Creates an attribute from name, value and type using IppAttributesParser. */
+    fun createAttribute(name: String, value: Any, type: String): Attribute<*>? {
         return try {
-            when (type) {
-                "integer", "enum" -> when (valueAny) {
-                    is Number -> IntAttribute(name, valueAny.toInt())
-                    is String -> valueAny.toIntOrNull()?.let { IntAttribute(name, it) } ?: StringAttribute(name, valueAny)
-                    else -> StringAttribute(name, valueAny.toString())
+            val json =
+                JSONObject().apply {
+                    put("type", type)
+                    put("value", value)
                 }
-                "boolean" -> when (valueAny) {
-                    is Boolean -> BooleanAttribute(name, valueAny)
-                    is String -> BooleanAttribute(name, valueAny.equals("true", true))
-                    else -> BooleanAttribute(name, false)
-                }
-                // Treat all others as strings while preserving content
-                else -> StringAttribute(name, valueAny.toString())
-            }
+            IppAttributesParser.parseExplicitTypedAttribute(name, json)
         } catch (e: Exception) {
-            Log.w(TAG, "Falling back to string attribute for $name", e)
-            StringAttribute(name, valueAny.toString())
+            Log.e(TAG, "Error creating attribute: $name", e)
+            null
         }
     }
-    
-    /**
-     * Gets list of available IPP attribute files
-     */
+
+    /** Gets list of available IPP attribute files in custom attributes directory. */
     fun getAvailableIppAttributeFiles(context: Context): List<String> {
         val attributesDir = File(context.filesDir, CUSTOM_ATTRIBUTES_DIR)
         if (!attributesDir.exists()) {
@@ -693,223 +293,29 @@ object IppAttributesUtils {
         }
         return attributesDir.listFiles()?.map { it.name } ?: emptyList()
     }
-    
-    /**
-     * Deletes an IPP attributes file
-     */
+
+    /** Deletes an IPP attributes file. */
     fun deleteIppAttributes(context: Context, filename: String): Boolean {
-        try {
-            val file = File(context.filesDir, "$CUSTOM_ATTRIBUTES_DIR/$filename")
-            return if (file.exists()) {
-                file.delete()
-            } else {
-                false
-            }
+        return try {
+            val file = File(File(context.filesDir, CUSTOM_ATTRIBUTES_DIR), filename)
+            if (file.exists()) file.delete() else false
         } catch (e: Exception) {
             Log.e(TAG, "Error deleting IPP attributes file", e)
-            return false
+            false
         }
     }
-    
-    /**
-     * Validates IPP attributes with different levels of strictness
-     */
+
+    /** Validates IPP attributes using IppAttributesParser validation. */
     fun validateIppAttributes(attributes: List<AttributeGroup>?, strict: Boolean = false): Boolean {
-        if (attributes == null || attributes.isEmpty()) {
+        if (attributes.isNullOrEmpty()) {
             Log.w(TAG, "Validation failed: No attributes provided")
             return false
         }
-        
-        // Basic validation - just check that we have valid groups with valid attributes
-        var hasValidGroups = false
-        var totalAttributes = 0
-        
-        for (group in attributes) {
-            try {
-                val attributesInGroup = getAttributesFromGroup(group)
-                if (attributesInGroup.isNotEmpty()) {
-                    hasValidGroups = true
-                    totalAttributes += attributesInGroup.size
-                    
-                    // Check that all attributes have valid names
-                    for (attr in attributesInGroup) {
-                        if (attr.name.isBlank()) {
-                            Log.w(TAG, "Validation failed: Found attribute with blank name")
-                            return false
-                        }
-                    }
-                }
-            } catch (e: Exception) {
-                Log.w(TAG, "Validation failed: Error processing attribute group", e)
-                return false
-            }
+        val allAttributes = attributes.flatMap { it.toList() }
+        val errors = IppAttributesParser.validate(allAttributes)
+        for (err in errors) {
+            Log.w(TAG, "IPP attribute validation warning: $err")
         }
-        
-        if (!hasValidGroups) {
-            Log.w(TAG, "Validation failed: No valid attribute groups found")
-            return false
-        }
-        
-        // Strict validation for printer-specific requirements
-        if (strict) {
-            val requiredGroups = setOf(Tag.printerAttributes)
-            val requiredAttributes = setOf(
-                "printer-name",
-                "printer-state", 
-                "printer-is-accepting-jobs"
-            )
-            
-            val hasRequiredGroups = attributes.any { it.tag in requiredGroups }
-            val hasRequiredAttributes = attributes.any { group ->
-                val attributesInGroup = getAttributesFromGroup(group)
-                attributesInGroup.any { attr -> attr.name in requiredAttributes }
-            }
-            
-            if (!hasRequiredGroups || !hasRequiredAttributes) {
-                Log.w(TAG, "Strict validation failed: Missing required printer attributes")
-                return false
-            }
-        }
-        
-        Log.d(TAG, "Validation passed: ${attributes.size} groups, $totalAttributes total attributes")
-        return true
+        return if (strict) errors.isEmpty() else true
     }
-    
-    /**
-     * Helper to get a Tag by name
-     */
-    fun getTagByName(name: String): Tag? {
-        return when (name.uppercase()) {
-            "PRINTER_ATTRIBUTES" -> Tag.printerAttributes
-            "JOB_ATTRIBUTES" -> Tag.jobAttributes
-            "OPERATION_ATTRIBUTES" -> Tag.operationAttributes
-            "DOCUMENT_ATTRIBUTES" -> Tag.documentAttributes
-            "UNSUPPORTED_ATTRIBUTES" -> Tag.unsupportedAttributes
-            else -> null
-        }
-    }
-    
-    /**
-     * Create an AttributeGroup with the given tag and attributes
-     */
-    fun createAttributeGroup(tag: Tag, attributes: List<Attribute<*>>): AttributeGroup {
-        // Simplified implementation that wraps the attributes
-        return object : AttributeGroup {
-            override val tag: com.hp.jipp.encoding.DelimiterTag = tag as com.hp.jipp.encoding.DelimiterTag
-            override val size: Int = attributes.size
-            
-            override fun isEmpty(): Boolean = attributes.isEmpty()
-            
-            override fun iterator(): Iterator<Attribute<*>> = attributes.iterator()
-            
-            override fun listIterator(): kotlin.collections.ListIterator<Attribute<*>> = attributes.listIterator()
-            
-            override fun listIterator(index: Int): kotlin.collections.ListIterator<Attribute<*>> = attributes.listIterator(index)
-            
-            override fun subList(fromIndex: Int, toIndex: Int): List<Attribute<*>> = attributes.subList(fromIndex, toIndex)
-            
-            override fun contains(element: Attribute<*>): Boolean {
-                return attributes.any { it.name == element.name }
-            }
-            
-            override fun containsAll(elements: Collection<Attribute<*>>): Boolean {
-                return elements.all { contains(it) }
-            }
-            
-            override fun get(index: Int): Attribute<*> {
-                if (index < 0 || index >= attributes.size) throw IndexOutOfBoundsException()
-                return attributes[index]
-            }
-            
-            override fun indexOf(element: Attribute<*>): Int {
-                return attributes.indexOfFirst { it.name == element.name }
-            }
-            
-            override fun lastIndexOf(element: Attribute<*>): Int {
-                return attributes.indexOfLast { it.name == element.name }
-            }
-            
-            @Suppress("UNCHECKED_CAST")
-            override operator fun <T : Any> get(type: AttributeType<T>): Attribute<T>? {
-                return attributes.firstOrNull { it.name == type.name } as? Attribute<T>
-            }
-            
-            override operator fun get(name: String): Attribute<*>? {
-                return attributes.firstOrNull { it.name == name }
-            }
-            
-            override fun toString(): String {
-                return "AttributeGroup(tag=$tag, attributes=${attributes.size})"
-            }
-        }
-    }
-    
-    /**
-     * Converts IPP attributes to a JSON string
-     */
-    fun ippAttributesToJson(attributes: List<AttributeGroup>): String {
-        val jsonObject = JSONObject()
-        val attributeGroupsArray = JSONArray()
-        
-        attributes.forEach { group ->
-            val groupObject = JSONObject()
-            groupObject.put("tag", group.tag.name)
-            
-            val attributesArray = JSONArray()
-            val attributesInGroup = getAttributesFromGroup(group)
-            
-            attributesInGroup.forEach { attr ->
-                val attributeObject = JSONObject()
-                attributeObject.put("name", attr.name)
-                
-                when {
-                    attr.size > 1 -> {
-                        // Handle multi-value attributes
-                        val valuesArray = JSONArray()
-                        for (i in 0 until attr.size) {
-                            valuesArray.put(attr[i].toString())
-                        }
-                        attributeObject.put("values", valuesArray)
-                        attributeObject.put("type", "collection")
-                    }
-                    else -> {
-                        // Handle single-value attributes
-                        attributeObject.put("value", attr.toString())
-                        attributeObject.put("type", getAttributeType(attr))
-                    }
-                }
-                
-                attributesArray.put(attributeObject)
-            }
-            
-            groupObject.put("attributes", attributesArray)
-            attributeGroupsArray.put(groupObject)
-        }
-        
-        jsonObject.put("attributeGroups", attributeGroupsArray)
-        return jsonObject.toString(2)  // Pretty print with 2-space indentation
-    }
-    
-    /**
-     * Saves IPP attributes as a formatted JSON file
-     */
-    fun saveIppAttributesAsJson(context: Context, attributes: List<AttributeGroup>, filename: String): Boolean {
-        try {
-            val jsonString = ippAttributesToJson(attributes)
-            
-            val attributesDir = File(context.filesDir, CUSTOM_ATTRIBUTES_DIR)
-            if (!attributesDir.exists()) {
-                attributesDir.mkdirs()
-            }
-            
-            val file = File(attributesDir, filename)
-            FileOutputStream(file).use { it.write(jsonString.toByteArray()) }
-            
-            Log.d(TAG, "Saved IPP attributes as JSON to: ${file.absolutePath}")
-            return true
-        } catch (e: Exception) {
-            Log.e(TAG, "Error saving IPP attributes as JSON", e)
-            return false
-        }
-    }
-} 
+}

--- a/app/src/main/java/com/google/virtualprinter/utils/PreferenceUtils.kt
+++ b/app/src/main/java/com/google/virtualprinter/utils/PreferenceUtils.kt
@@ -33,7 +33,7 @@ object PreferenceUtils {
     private const val KEY_PRINTER_UUID = "printer_uuid"
     private const val DEFAULT_PRINTER_NAME = "Android Virtual Printer"
     
-    private const val CONFIG_FILE_NAME = "printer_config.json"
+    const val CONFIG_FILE_NAME = "printer_config.json"
     private const val KEY_CONFIG_PRINTER_NAME = "printer_name"
     private const val KEY_CONFIG_PRINTER_UUID = "printer_uuid"
     private const val KEY_CONFIG_SUPPORTED_FORMATS = "supported_formats"

--- a/app/src/test/java/com/google/virtualprinter/utils/IppAttributesUtilsTest.kt
+++ b/app/src/test/java/com/google/virtualprinter/utils/IppAttributesUtilsTest.kt
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2026 The Virtual Printer Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.virtualprinter.utils
+
+import com.google.common.truth.Truth.assertThat
+import com.hp.jipp.encoding.AttributeGroup
+import com.hp.jipp.encoding.IppPacket
+import com.hp.jipp.encoding.Tag
+import com.hp.jipp.model.Status
+import com.hp.jipp.model.Types
+import java.io.ByteArrayOutputStream
+import java.io.File
+import org.json.JSONObject
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class IppAttributesUtilsTest {
+
+    @get:Rule val tempFolder = TemporaryFolder()
+
+    @Test
+    fun loadIppAttributes_fromFile_parsesPrinterAndOperationAttributes() {
+        val file = tempFolder.newFile("test_config.json")
+        file.writeText(
+            """
+            {
+                "operation-attributes": {
+                    "attributes-charset": {
+                        "type": "charset",
+                        "value": "utf-8"
+                    }
+                },
+                "printer-attributes": {
+                    "color-supported": {
+                        "type": "boolean",
+                        "value": true
+                    }
+                }
+            }
+            """
+                .trimIndent()
+        )
+
+        val groups = IppAttributesUtils.loadIppAttributes(file)
+        assertThat(groups).isNotNull()
+        assertThat(groups).hasSize(2)
+
+        val opGroup = groups!!.find { it.tag == Tag.operationAttributes }
+        assertThat(opGroup).isNotNull()
+        assertThat(opGroup!!["attributes-charset"]?.getValue()).isEqualTo("utf-8")
+
+        val prGroup = groups.find { it.tag == Tag.printerAttributes }
+        assertThat(prGroup).isNotNull()
+        assertThat(prGroup!!["color-supported"]?.getValue()).isEqualTo(true)
+    }
+
+    @Test
+    fun loadIppAttributes_missingFile_returnsNull() {
+        val file = File(tempFolder.root, "non_existent.json")
+        val groups = IppAttributesUtils.loadIppAttributes(file)
+        assertThat(groups).isNull()
+    }
+
+    @Test
+    fun overlayAttributes_overwritesMatchingAttributesAndPreservesOthers() {
+        val basePacket =
+            IppPacket(
+                Status.successfulOk,
+                1,
+                AttributeGroup.groupOf(
+                    Tag.operationAttributes,
+                    Types.attributesCharset.of("utf-8"),
+                    Types.attributesNaturalLanguage.of("en"),
+                ),
+                AttributeGroup.groupOf(
+                    Tag.printerAttributes,
+                    Types.printerName.of("Default Printer"),
+                    Types.colorSupported.of(false),
+                    Types.queuedJobCount.of(0),
+                ),
+            )
+
+        val overrides =
+            listOf(
+                AttributeGroup.groupOf(
+                    Tag.printerAttributes,
+                    Types.printerName.of("Custom Printer"),
+                    Types.colorSupported.of(true),
+                )
+            )
+
+        val merged = IppAttributesUtils.overlayAttributes(basePacket, overrides)
+        val prGroup = merged.attributeGroups.find { it.tag == Tag.printerAttributes }
+        assertThat(prGroup).isNotNull()
+
+        // Overridden values
+        val printerName = IppAttributesUtils.extractString(prGroup!![Types.printerName]?.getValue())
+        assertThat(printerName).isEqualTo("Custom Printer")
+        assertThat(prGroup[Types.colorSupported]?.getValue()).isEqualTo(true)
+
+        // Preserved baseline values
+        assertThat(prGroup[Types.queuedJobCount]?.getValue()).isEqualTo(0)
+
+        // Preserved operation attributes
+        val opGroup = merged.attributeGroups.find { it.tag == Tag.operationAttributes }
+        assertThat(opGroup).isNotNull()
+        val charset =
+            IppAttributesUtils.extractString(opGroup!![Types.attributesCharset]?.getValue())
+        assertThat(charset).isEqualTo("utf-8")
+    }
+
+    @Test
+    fun ippAttributesToJson_roundTripsWithParser() {
+        val groups =
+            listOf(
+                AttributeGroup.groupOf(
+                    Tag.printerAttributes,
+                    Types.printerName.of("Test Virtual Printer"),
+                    Types.colorSupported.of(true),
+                    Types.documentFormatSupported.of("application/pdf", "image/pwg-raster"),
+                )
+            )
+
+        val jsonString = IppAttributesUtils.ippAttributesToJson(groups)
+        val root = JSONObject(jsonString)
+        val prJson = root.getJSONObject("printer-attributes")
+
+        val parsedAttributes = IppAttributesParser.parse(prJson)
+        val attrMap = parsedAttributes.associateBy { it.name }
+
+        val prName = IppAttributesUtils.extractString(attrMap[Types.printerName.name]?.getValue())
+        assertThat(prName).isEqualTo("Test Virtual Printer")
+        assertThat(attrMap[Types.colorSupported.name]?.getValue()).isEqualTo(true)
+
+        val docFormats = attrMap[Types.documentFormatSupported.name]?.map {
+            IppAttributesUtils.extractString(it)
+        }
+        assertThat(docFormats).containsExactly("application/pdf", "image/pwg-raster")
+    }
+
+    @Test
+    fun saveIppAttributes_toOutputStream_writesValidJson() {
+        val groups =
+            listOf(AttributeGroup.groupOf(Tag.printerAttributes, Types.colorSupported.of(true)))
+
+        val outputStream = ByteArrayOutputStream()
+        val success = IppAttributesUtils.saveIppAttributes(outputStream, groups)
+        assertThat(success).isTrue()
+
+        val jsonString = outputStream.toString()
+        assertThat(jsonString).contains("\"printer-attributes\"")
+        assertThat(jsonString).contains("\"color-supported\"")
+    }
+
+    @Test
+    fun createAttribute_createsNativeJippAttributes() {
+        val intAttr = IppAttributesUtils.createAttribute("test-int", 42, "INTEGER")
+        assertThat(intAttr).isNotNull()
+        assertThat(intAttr!!.name).isEqualTo("test-int")
+        assertThat(intAttr.getValue()).isEqualTo(42)
+
+        val boolAttr = IppAttributesUtils.createAttribute("test-bool", true, "BOOLEAN")
+        assertThat(boolAttr).isNotNull()
+        assertThat(boolAttr!!.name).isEqualTo("test-bool")
+        assertThat(boolAttr.getValue()).isEqualTo(true)
+
+        val strAttr = IppAttributesUtils.createAttribute("test-str", "hello", "STRING")
+        assertThat(strAttr).isNotNull()
+        assertThat(strAttr!!.name).isEqualTo("test-str")
+        assertThat(strAttr.getValue()).isEqualTo("hello")
+
+        val rangeAttr =
+            IppAttributesUtils.createAttribute("copies-supported", "(1:100)", "rangeOfInteger")
+        assertThat(rangeAttr).isNotNull()
+        assertThat(rangeAttr!!.name).isEqualTo("copies-supported")
+
+        val resAttr =
+            IppAttributesUtils.createAttribute(
+                "printer-resolution-default",
+                "600x600dpi",
+                "resolution",
+            )
+        assertThat(resAttr).isNotNull()
+        assertThat(resAttr!!.name).isEqualTo("printer-resolution-default")
+
+        val mimeAttr =
+            IppAttributesUtils.createAttribute(
+                "document-format-supported",
+                "application/pdf",
+                "mimeMediaType",
+            )
+        assertThat(mimeAttr).isNotNull()
+        assertThat(mimeAttr!!.name).isEqualTo("document-format-supported")
+    }
+}

--- a/app/src/test/java/com/google/virtualprinter/utils/PreferenceUtilsTest.kt
+++ b/app/src/test/java/com/google/virtualprinter/utils/PreferenceUtilsTest.kt
@@ -80,7 +80,7 @@ class PreferenceUtilsTest {
     fun getCustomPrinterName_returnsConfigFileValue_whenSharedPreferencesNotSet() {
         every { mockPrefs.getString("printer_name", null) } returns null
 
-        val configFile = File(filesDir, "printer_config.json")
+        val configFile = File(filesDir, PreferenceUtils.CONFIG_FILE_NAME)
         configFile.writeText(
             """
             {
@@ -106,7 +106,7 @@ class PreferenceUtilsTest {
 
     @Test
     fun getPrinterUuid_returnsConfigFileValue_whenConfigExists() {
-        val configFile = File(filesDir, "printer_config.json")
+        val configFile = File(filesDir, PreferenceUtils.CONFIG_FILE_NAME)
         configFile.writeText(
             """
             {
@@ -143,7 +143,7 @@ class PreferenceUtilsTest {
 
     @Test
     fun getSupportedFormats_returnsFormatsFromConfigFile() {
-        val configFile = File(filesDir, "printer_config.json")
+        val configFile = File(filesDir, PreferenceUtils.CONFIG_FILE_NAME)
         configFile.writeText(
             """
             {
@@ -177,7 +177,7 @@ class PreferenceUtilsTest {
 
     @Test
     fun getCompressionSupported_returnsCompressionFromConfigFile() {
-        val configFile = File(filesDir, "printer_config.json")
+        val configFile = File(filesDir, PreferenceUtils.CONFIG_FILE_NAME)
         configFile.writeText(
             """
             {


### PR DESCRIPTION
Replaced legacy, limited attribute parsing heuristics in IppAttributesUtils with the full-featured IppAttributesParser.

Deleted obsolete custom attribute wrapper classes and helpers in favor of native JIPP types.

Fixed a bug in PrinterService where custom IPP attributes completely replaced default attributes instead of merging with them via overlayAttributes(), which previously broke responses when only customizing a subset of attributes.

Added auto-loading of printer_config.json in PrinterService and modernized SettingsScreen attribute export to use standard RFC 8011 JSON.

Added comprehensive unit tests in IppAttributesUtilsTest.
